### PR TITLE
Use extra-lib-dirs in the buildinfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 /cufft.buildinfo
 /configure
 /dist/
+
+autom4te.cache/
+

--- a/configure.ac
+++ b/configure.ac
@@ -112,5 +112,6 @@ cuda_ldflags="$LDFLAGS $LIBS "
 AC_SUBST([cuda_cppflags])
 AC_SUBST([cuda_ldflags])
 AC_SUBST([cuda_c2hsflags])
+AC_SUBST([cuda_lib_path])
 AC_OUTPUT
 

--- a/cufft.buildinfo.in
+++ b/cufft.buildinfo.in
@@ -2,3 +2,4 @@ ghc-options: -optc@cuda_cppflags@
 cc-options: @cuda_cppflags@
 ld-options: @cuda_ldflags@
 x-extra-c2hs-options: @cuda_c2hsflags@
+extra-lib-dirs: @cuda_lib_path@


### PR DESCRIPTION
With this fix, you don't need to set DYLD_LIBRARY_PATH when loading the package into ghci.
