### PR TITLE
use extra-libraries: cufft

### DIFF
--- a/cufft.cabal
+++ b/cufft.cabal
@@ -44,6 +44,7 @@ library
   ghc-options:          -Wall -O2 -funbox-strict-fields -fwarn-tabs
 
   include-dirs:         .
+  extra-libraries:      cufft
 
 Source-repository head
   Type:                 git


### PR DESCRIPTION
I found that this cufft haskell library needs to be linked with `libcufft.so`. Putting "extra-libraries: cufft" in `cufft.cabal` solves the link problem. Is there any special reason not to do that? 
