### PR TITLE
Add travis-ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,84 @@
+language: haskell
+env:
+    - CUDA=6.5-14 GHC=7.6.3
+    - CUDA=6.5-14 GHC=7.8.4
+    - CUDA=6.5-14 GHC=7.10.1
+    - CUDA=7.0-28 GHC=7.6.3
+    - CUDA=7.0-28 GHC=7.8.4
+    - CUDA=7.0-28 GHC=7.10.1
+    - CUDA=7.0-28 GHC=head
+#    - CUDA=6.0-37
+
+matrix:
+    allow_failures:
+        - env: CUDA=7.0-28 GHC=head
+
+before_install:
+    # If travis doesn't have the version of GHC that we want, get it from hvr's PPA
+    - echo "Setting up GHC"
+    - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
+    - travis_retry sudo apt-get update -qq
+    - travis_retry sudo apt-get install -y c2hs
+    - export PATH=/usr/local/ghc/${GHC}/bin:${PATH}
+    - |
+        if [ $(ghc --numeric-version) != ${GHC} ]; then
+            travis_retry sudo apt-get install -y ghc-${GHC}
+            export PATH=/opt/ghc/${GHC}/bin:${PATH}
+        fi
+    - |
+        if [ ${GHC} = "head" ]; then
+            travis_retry sudo apt-get install -y cabal-install-head
+            export PATH=/opt/cabal/head/bin:${PATH}
+        fi
+
+    # If we want to build c2hs from source, ghc-7.8 and later will require newer
+    # versions of happy and alex
+    #    - |
+    #        if [ ${GHC%.*} != 7.6 ]; then
+    #            travis_retry sudo apt-get install -y happy-1.19.4 alex-3.1.3
+    #            export PATH=/opt/alex/3.1.3/bin:/opt/happy/1.19.4/bin:${PATH}
+    #        fi
+    #    - cabal install c2hs
+
+    - echo "Installing CUDA library"
+    - travis_retry wget http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1204/x86_64/cuda-repo-ubuntu1204_${CUDA}_amd64.deb
+    - travis_retry sudo dpkg -i cuda-repo-ubuntu1204_${CUDA}_amd64.deb
+    - travis_retry sudo apt-get update -qq
+    - export CUDA_APT=${CUDA%-*}
+    - export CUDA_APT=${CUDA_APT/./-}
+#    - travis_retry sudo apt-get install -y cuda-${CUDA_APT}
+    - travis_retry sudo apt-get install -y cuda-drivers cuda-core-${CUDA_APT} cuda-cudart-dev-${CUDA_APT} cuda-cufft-dev-${CUDA_APT}
+    - travis_retry sudo apt-get clean
+    - export CUDA_HOME=/usr/local/cuda-${CUDA%%-*}
+    - export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${LD_LIBRARY_PATH}
+    - export PATH=${CUDA_HOME}/bin:${PATH}
+
+install:
+    - ghc --version
+    - cabal --version
+    - nvcc --version
+    - cabal install --only-dependencies --enable-tests
+
+script:
+    # Check the build
+    - cabal configure -v2 -flib-Werror
+    - cabal build
+    - cabal haddock
+#    - cabal test --show-details=always
+
+    # Check the source distribution can be generated, built, and installed
+    - cabal sdist
+    - |
+        export SRC_TGZ=$(cabal info . | awk '{print $2 ".tar.gz";exit}')
+        cd dist
+        if [ -f "$SRC_TGZ" ]; then
+            cabal install --force-reinstalls ${SRC_TGZ}
+        else
+            echo "'$SRC_TGZ': not found"
+            exit 1
+        fi
+
+after_failure:
+    - dmesg
+    - ls -R /usr/local/cuda*
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,6 @@ before_install:
             travis_retry sudo apt-get install -y ghc-${GHC}
             export PATH=/opt/ghc/${GHC}/bin:${PATH}
         fi
-    - |
-        if [ ${GHC} = "head" ]; then
-            travis_retry sudo apt-get install -y cabal-install-head
-            export PATH=/opt/cabal/head/bin:${PATH}
-        fi
 
     # If we want to build c2hs from source, ghc-7.8 and later will require newer
     # versions of happy and alex

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Haskell FFI Bindings to CUDA FFT
 ================================
 
-[![Build status](https://travis-ci.org/tmcdonell/cuda.svg?branch=master)](https://travis-ci.org/tmcdonell/cuda)
+[![Build status](https://travis-ci.org/tmcdonell/cufft.svg?branch=master)](https://travis-ci.org/tmcdonell/cufft)
 
 The CUFFT library provides high performance implementations of Fast Fourier
 Transform (FFT) operations on NVIDIA GPUs. This is a collection of bindings to

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+Haskell FFI Bindings to CUDA FFT
+================================
+
+[![Build status](https://travis-ci.org/tmcdonell/cuda.svg?branch=master)](https://travis-ci.org/tmcdonell/cuda)
+
+The CUFFT library provides high performance implementations of Fast Fourier
+Transform (FFT) operations on NVIDIA GPUs. This is a collection of bindings to
+allow you to call those functions from Haskell. You will need to install the
+CUDA driver and developer toolkit.
+
+[http://developer.nvidia.com/cuda-downloads][cuda]
+
+The configure script will look for your CUDA installation in the standard
+places, and if the `nvcc` compiler is found in your `PATH`, relative to that.
+
+[cuda]: http://developer.nvidia.com/object/cuda.html
+
+

--- a/Setup.hs
+++ b/Setup.hs
@@ -12,7 +12,7 @@ import Distribution.Simple.PreProcess           hiding (ppC2hs)
 
 import Control.Exception
 import Control.Monad
-import System.Exit
+import System.Exit                              hiding (die)
 import System.FilePath
 import System.Directory
 import System.Environment


### PR DESCRIPTION
You'll need to go to travis-ci.org and allow it access to your Github, then enable it for this repo. You may then want to change the build status URL in README.md.

This also fixes the build for ghc-7.10, and adds a README file.