### PR TITLE
travis improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ script:
         export SRC_TGZ=$(cabal info . | awk '{print $2 ".tar.gz";exit}')
         cd dist
         if [ -f "$SRC_TGZ" ]; then
-            cabal install --force-reinstalls ${SRC_TGZ}
+            cabal install --force-reinstalls ${SRC_TGZ} || exit 1
         else
             echo "'$SRC_TGZ': not found"
             exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: haskell
 env:
+  global:
+    - HAPPY=1.19.5
+    - ALEX=3.1.4
+
+  matrix:
     - CUDA=6.5-14 GHC=7.6.3
     - CUDA=6.5-14 GHC=7.8.4
     - CUDA=6.5-14 GHC=7.10.1
@@ -10,30 +15,35 @@ env:
 #    - CUDA=6.0-37
 
 matrix:
-    allow_failures:
-        - env: CUDA=7.0-28 GHC=head
+  allow_failures:
+    - env: CUDA=7.0-28 GHC=head
 
 before_install:
     # If travis doesn't have the version of GHC that we want, get it from hvr's PPA
     - echo "Setting up GHC"
     - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
     - travis_retry sudo apt-get update -qq
-    - travis_retry sudo apt-get install -y c2hs
+      # - travis_retry sudo apt-get install -y c2hs
     - export PATH=/usr/local/ghc/${GHC}/bin:${PATH}
     - |
         if [ $(ghc --numeric-version) != ${GHC} ]; then
             travis_retry sudo apt-get install -y ghc-${GHC}
             export PATH=/opt/ghc/${GHC}/bin:${PATH}
         fi
+    - |
+        if [ ${CABAL} ]; then
+            travis_retry sudo apt-get install -y cabal-install-${CABAL}
+            export PATH=/opt/cabal/${CABAL}/bin:${PATH}
+        fi
 
     # If we want to build c2hs from source, ghc-7.8 and later will require newer
     # versions of happy and alex
-    #    - |
-    #        if [ ${GHC%.*} != 7.6 ]; then
-    #            travis_retry sudo apt-get install -y happy-1.19.4 alex-3.1.3
-    #            export PATH=/opt/alex/3.1.3/bin:/opt/happy/1.19.4/bin:${PATH}
-    #        fi
-    #    - cabal install c2hs
+    - |
+        if [ ${GHC%.*} != 7.6 ]; then
+            travis_retry sudo apt-get install -y alex-${ALEX} happy-${HAPPY}
+            export PATH=/opt/alex/${ALEX}/bin:/opt/happy/${HAPPY}/bin:${PATH}
+        fi
+    - cabal install c2hs
 
     - echo "Installing CUDA library"
     - travis_retry wget http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1204/x86_64/cuda-repo-ubuntu1204_${CUDA}_amd64.deb
@@ -51,6 +61,7 @@ before_install:
 install:
     - ghc --version
     - cabal --version
+    - c2hs --version
     - nvcc --version
     - cabal install --only-dependencies --enable-tests
 


### PR DESCRIPTION
 * This now correctly fails if installing from source fails
 * Install c2hs from source, to handle future versions of the cuda bindings package