### PR TITLE
Resurrect support for Cabal-1.22

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,9 +60,14 @@ matrix:
 before_install:
   - export PATH=/opt/ghc/$GHC/bin:/opt/cabal/$CABAL/bin:/opt/alex/3.1.7/bin:/opt/happy/1.19.5/bin:$HOME/.cabal/bin:$PATH
 
-  # Need to install a newer version of the Cabal library in order to run the Setup.hs script
+  # Need at least Cabal-1.22 to run the Setup.hs script. This is the default
+  # version of GHC-7.10 and later.
   - cabal update
-  - cabal install Cabal --constraint="Cabal >= 1.24"
+  - |
+      case ${GHC} in
+        7.6.*) cabal install Cabal --constraint="Cabal >= 1.22" ;;
+        7.8.*) cabal install Cabal --constraint="Cabal >= 1.22" ;;
+      esac
   - cabal install c2hs
 
   # Install the CUDA toolkit

--- a/Setup.hs
+++ b/Setup.hs
@@ -118,8 +118,13 @@ main = defaultMainWithHooks customHooks
             localUnitId lbi
 #else
             $( case withinRange cabalVersion (orLaterVersion (Version [1,24] [])) of
-                 True  -> return ( AppE (VarE (mkName "localUnitId")) (VarE (mkName "lbi")) ) -- [| localUnitId lbi |]
-                 False -> [| head (componentLibraries (getComponentLocalBuildInfo lbi CLibName)) |]
+                 True  -> return ( AppE (VarE (mkName "localUnitId")) (VarE (mkName "lbi")) )
+                 False -> return ( AppE (VarE (mkName "head"))
+                                        (AppE (VarE (mkName ("componentLibraries")))
+                                        (AppE (AppE (VarE (mkName "getComponentLocalBuildInfo")) (VarE (mkName "lbi"))) (ConE (mkName "CLibName")))) )
+
+                 -- True  -> [| localUnitId lbi |] -- [| localUnitId lbi |]
+                 -- False -> [| head (componentLibraries (getComponentLocalBuildInfo lbi CLibName)) |]
              )
 #endif
           sharedLib           = buildDir lbi </> mkSharedLibName cid uid

--- a/Setup.hs
+++ b/Setup.hs
@@ -123,7 +123,7 @@ main = defaultMainWithHooks customHooks
                                         (AppE (VarE (mkName ("componentLibraries")))
                                         (AppE (AppE (VarE (mkName "getComponentLocalBuildInfo")) (VarE (mkName "lbi"))) (ConE (mkName "CLibName")))) )
 
-                 -- True  -> [| localUnitId lbi |] -- [| localUnitId lbi |]
+                 -- True  -> [| localUnitId lbi |]
                  -- False -> [| head (componentLibraries (getComponentLocalBuildInfo lbi CLibName)) |]
              )
 #endif

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,3 +1,11 @@
+{-# LANGUAGE CPP             #-}
+{-# LANGUAGE QuasiQuotes     #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+-- The MIN_VERSION_Cabal macro was introduced with Cabal-1.24 (??)
+#ifndef MIN_VERSION_Cabal
+#define MIN_VERSION_Cabal(major1,major2,minor) 0
+#endif
 
 import Distribution.PackageDescription
 import Distribution.PackageDescription.Parse
@@ -8,10 +16,16 @@ import Distribution.Simple.LocalBuildInfo
 import Distribution.Simple.PreProcess                               hiding ( ppC2hs )
 import Distribution.Simple.Program
 import Distribution.Simple.Program.Db
+import Distribution.Simple.Program.Find
 import Distribution.Simple.Setup
 import Distribution.Simple.Utils
 import Distribution.System
 import Distribution.Verbosity
+
+#if MIN_VERSION_Cabal(1,25,0)
+import Distribution.PackageDescription.PrettyPrint
+import Distribution.Version
+#endif
 
 import Control.Applicative
 import Control.Exception
@@ -22,6 +36,8 @@ import System.FilePath
 import System.IO.Error
 import Text.Printf
 import Prelude
+
+import Language.Haskell.TH
 
 
 -- Configuration
@@ -97,7 +113,15 @@ main = defaultMainWithHooks customHooks
           verbosity           = fromFlag (buildVerbosity flags)
           platform            = hostPlatform lbi
           cid                 = compilerId (compiler lbi)
-          uid                 = localUnitId lbi
+          uid                 =
+#if MIN_VERSION_Cabal(1,25,0)
+            localUnitId lbi
+#else
+            $( case withinRange cabalVersion (orLaterVersion (Version [1,24] [])) of
+                 True  -> return ( AppE (VarE (mkName "localUnitId")) (VarE (mkName "lbi")) ) -- [| localUnitId lbi |]
+                 False -> [| head (componentLibraries (getComponentLocalBuildInfo lbi CLibName)) |]
+             )
+#endif
           sharedLib           = buildDir lbi </> mkSharedLibName cid uid
           Just extraLibDirs'  = extraLibDirs . libBuildInfo <$> library pkg_descr
       --
@@ -265,9 +289,14 @@ findProgramLocationOrError verbosity execName = do
 findProgram :: Verbosity -> FilePath -> IO (Maybe FilePath)
 findProgram verbosity prog = do
   result <- findProgramOnSearchPath verbosity defaultProgramSearchPath prog
-  case result of
-    Nothing       -> return Nothing
-    Just (path,_) -> return (Just path)
+#if MIN_VERSION_Cabal(1,25,0)
+  return (fmap fst result)
+#else
+  $( case withinRange cabalVersion (orLaterVersion (Version [1,24] [])) of
+       True  -> [| return (fmap fst result) |]
+       False -> [| return result |]
+    )
+#endif
 
 
 cudaNotFoundMsg :: String
@@ -475,8 +504,13 @@ windowsLinkerBugMsg ldPath = printf (unlines msg) windowsHelpPage ldPath
 --
 -- Everything below copied from Distribution.Simple.PreProcess
 --
+#if MIN_VERSION_Cabal(1,25,0)
+ppC2hs :: BuildInfo -> LocalBuildInfo -> ComponentLocalBuildInfo -> PreProcessor
+ppC2hs bi lbi _clbi =
+#else
 ppC2hs :: BuildInfo -> LocalBuildInfo -> PreProcessor
 ppC2hs bi lbi =
+#endif
   PreProcessor
     { platformIndependent = False
     , runPreProcessor     = \(inBaseDir, inRelativeFile) (outBaseDir, outRelativeFile) verbosity ->
@@ -509,7 +543,14 @@ hcDefines comp =
 -- FIXME: this forces GHC's crazy 4.8.2 -> 408 convention on all the other
 -- compilers. Check if that's really what they want.
 versionInt :: Version -> String
-versionInt (Version { versionBranch = [] })      = "1"
-versionInt (Version { versionBranch = [n] })     = show n
-versionInt (Version { versionBranch = n1:n2:_ }) = printf "%d%02d" n1 n2
+versionInt v =
+  case versionBranch v of
+    []      -> "1"
+    [n]     -> show n
+    n1:n2:_ -> printf "%d%02d" n1 n2
+
+#if MIN_VERSION_Cabal(1,25,0)
+versionBranch :: Version -> [Int]
+versionBranch = versionNumbers
+#endif
 

--- a/cufft.cabal
+++ b/cufft.cabal
@@ -24,7 +24,7 @@ homepage:               https://github.com/robeverest/cufft
 bug-reports:            https://github.com/robeverest/cufft/issues
 category:               Foreign
 build-type:             Custom
-cabal-version:          >= 1.24
+cabal-version:          >= 1.22
 tested-with:            GHC >= 7.6
 
 Extra-tmp-files:        cufft.buildinfo.generated
@@ -35,9 +35,10 @@ Extra-source-files:     cbits/wrap.h
 custom-setup
   setup-depends:
       base              >= 4.6
-    , Cabal             >= 1.24
+    , Cabal             >= 1.22
     , directory         >= 1.0
     , filepath          >= 1.0
+    , template-haskell
 
 library
   exposed-modules:      Foreign.CUDA.FFT


### PR DESCRIPTION
This is pretty awful, but allows the package to build with out-of-the-box GHC-7.10 again.